### PR TITLE
Add b64 encoding and decoding for binary files. Update to qcelemental…

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [unreleased]
 
+### Added
+
+- Support for `AtomicInput.protocols.native_files`. User can now request QC package specific files generated during a computation.
+- Added support for TeraChem-specific `native_files`. c0/ca0/cb0 bytes files (or any bytes data) placed in `AtomicInput.extras['tcfe:keywords']` will be automatically base64 encoded and sent to the server. The enables seeding computations with a wave function as an initial guess.
+- Base64 encoded `native_files` returned from server will be automatically decoded to bytes.
+
 ## [0.2.4]
 
 ### Added

--- a/docs/tutorial/terachem_cloud_algorithms.md
+++ b/docs/tutorial/terachem_cloud_algorithms.md
@@ -1,6 +1,6 @@
 # TeraChem Cloud Algorithms
 
-TeraChem Cloud implements some of its own concurrent algorithms that leverage its horizontally scalable backend infrastructure. These include a parallel hessian algorithm and parallel frequency analysis algorithm. To use them submit either a `hessian` or `properties` computation to TeraChem Cloud using `tcc` as the engine. Keywords specific to these algorithms are added to `.extras['tcc_kwargs']`. None are required and all are optional.
+TeraChem Cloud implements some of its own concurrent algorithms that leverage its horizontally scalable backend infrastructure. These include a parallel hessian algorithm and parallel frequency analysis algorithm. To use them submit either a `hessian` or `properties` computation to TeraChem Cloud using `tcc` as the engine. Keywords specific to these algorithms are added to `.extras['tcc:keywords']`. None are required and all are optional.
 
 ## Hessian
 
@@ -16,7 +16,7 @@ TeraChem Cloud implements some of its own concurrent algorithms that leverage it
 
 ## Keywords
 
-Keywords are passed in `AtomicInput.extras['tcc_kwargs']`.
+Keywords are passed in `AtomicInput.extras['tcc:keywords']`.
 
 | Keyword           | Type    | Description                                                 | Default Value  |
 | :---------------- | :------ | :---------------------------------------------------------- | :------------- |

--- a/examples/energy.py
+++ b/examples/energy.py
@@ -12,10 +12,14 @@ atomic_input = AtomicInput(
         "closed": True,
         "restricted": True,
     },
+    protocols={"stdout": True, "native_files": "all"},
+    extras={"tcfe:keywords": {"native_files": ["c0"]}},
 )
-future_result = client.compute(atomic_input, engine="terachem_pbs")
+future_result = client.compute(atomic_input, engine="terachem_fe")
 result = future_result.get()
 # AtomicResult object containing all returned data
 print(result)
 # The energy value requested
 print(result.return_result)
+print(result.stdout)
+print(result.native_files.keys())

--- a/examples/parallel_frequency_analysis.py
+++ b/examples/parallel_frequency_analysis.py
@@ -11,7 +11,7 @@ atomic_input = AtomicInput(
     model={"method": "B3LYP", "basis": "6-31g"},
     driver="properties",
     extras={
-        "tcc_kwargs": {
+        "tcc:keywords": {
             "temperature": 380.0,  # OPTIONAL: temperature for free energy calculation
         },
     },

--- a/examples/parallel_hessian.py
+++ b/examples/parallel_hessian.py
@@ -11,7 +11,7 @@ atomic_input = AtomicInput(
     model={"method": "B3LYP", "basis": "6-31g"},
     driver="hessian",
     extras={
-        "tcc_kwargs": {
+        "tcc:keywords": {
             "dh": 5e-3,  # OPTIONAL: displacement for finite difference
         },
     },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ home-page = "https://github.com/coltonbh/terachem-cloud-pyclient"
 module = "tccloud"
 
 requires = [
-  "qcelemental >= 0.17.0",
+  "qcelemental >= 0.24.0",
   "httpx >= 0.16.1",
   "toml >= 0.10.2",
 ]

--- a/tccloud/config.py
+++ b/tccloud/config.py
@@ -15,6 +15,7 @@ class Settings(BaseSettings):
     tccloud_domain: str = "https://tccloud.mtzlab.com"
     tccloud_api_version_prefix: str = "/api/v1"
     tccloud_default_credentials_profile: str = "default"
+    tcfe_config_kwarg: str = "tcfe:config"
 
 
 settings = Settings()

--- a/tccloud/http_client.py
+++ b/tccloud/http_client.py
@@ -17,6 +17,7 @@ from tccloud.models import (
 )
 
 from .config import Settings, settings
+from .utils import _b64_to_bytes, _bytes_to_b64
 
 
 class _RequestsClient:
@@ -270,6 +271,9 @@ class _RequestsClient:
         self, input_data: AtomicInputOrList, engine: str, queue: Optional[str] = None
     ) -> Union[FutureResult, FutureResultGroup]:
         """Submit a computation to TeraChem Cloud"""
+        # Convery any bytes data to b64 encoding
+        _bytes_to_b64(input_data)
+
         task = self._authenticated_request(
             "post",
             "/compute",
@@ -287,6 +291,9 @@ class _RequestsClient:
         queue: Optional[str] = None,
     ) -> Union[FutureResult, FutureResultGroup]:
         """Submit a procedure computation to Terachem Cloud"""
+        # Convert any bytes data to b64 encoding
+        _bytes_to_b64(input_data)
+
         task = self._authenticated_request(
             "post",
             "/compute-procedure",
@@ -315,6 +322,10 @@ class _RequestsClient:
         task_result = self._authenticated_request(
             "post", "/compute/result", data=json_dumps(task)
         )
+        if task_result["result"]:
+            # Convery b64 encoded native_files to bytes
+            _b64_to_bytes(task_result["result"])
+
         return task_result["compute_status"], task_result["result"]
 
     def hello_world(self, name: Optional[str] = None):

--- a/tccloud/utils.py
+++ b/tccloud/utils.py
@@ -1,0 +1,59 @@
+from base64 import b64decode, b64encode
+from typing import Any, Dict, List, Union
+
+from .config import settings
+from .models import AtomicInputOrList, OptimizationInput, OptimizationInputOrList
+
+B64_POSTFIX = "_b64"
+
+
+def _bytes_to_b64(
+    input_data: Union[AtomicInputOrList, OptimizationInputOrList]
+) -> None:
+    """Convert binary input data to base64 encoded strings"""
+
+    if not isinstance(input_data, list):
+        input_data = [input_data]
+
+    if isinstance(input_data[0], OptimizationInput):
+        input_data = [opt.input_specification for opt in input_data]
+
+    for inp in input_data:
+        tcfe_config = inp.extras.get(settings.tcfe_config_kwarg, {})
+        binary_files = [
+            key for key, value in tcfe_config.items() if isinstance(value, bytes)
+        ]
+        for key in binary_files:
+            file_bytes = tcfe_config.pop(key)
+            tcfe_config[f"{key}{B64_POSTFIX}"] = b64encode(file_bytes).decode()
+
+
+def _b64_to_bytes(results: Union[Dict[str, Any], List[Dict[str, Any]]]) -> None:
+    """Convert b64 encoded native_files to binary. Modifies objects in place.
+
+    Parameters:
+        results: Dictionary representation of models.PossibleResultsOrList
+    """
+
+    def _b64_to_bytes_dict(inp: Dict[str, Any]):
+        """Change b64 encoded dict values to binary"""
+        b64_keys = [key for key in inp.keys() if key.endswith(B64_POSTFIX)]
+        for key in b64_keys:
+            value = inp.pop(key)
+            inp[key.split(B64_POSTFIX)[0]] = b64decode(value)
+
+    if not isinstance(results, list):
+        results = [results]
+
+    for result in results:
+        if result["success"]:
+            # AtomicResult or OptimizationResult dictionary
+            if result.get("final_molecule"):
+                # Is OptimizationResult dict
+                for ai in result["trajectory"]:
+                    # Have to do .get() or due to native_files = Optional[Dict]
+                    # See https://github.com/MolSSI/QCElemental/pull/285
+                    _b64_to_bytes_dict(ai.get("native_files") or {})
+            else:
+                # Is AtomicInput dict
+                _b64_to_bytes_dict(result.get("native_files") or {})

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,141 @@
+from tccloud.models import (
+    AtomicInput,
+    AtomicResult,
+    OptimizationInput,
+    OptimizationResult,
+)
+from tccloud.utils import B64_POSTFIX, _b64_to_bytes, _bytes_to_b64
+
+
+def test_bytes_to_b64(water, settings):
+    ai = AtomicInput(
+        molecule=water,
+        model={"method": "b3lyp", "basis": "6-31g"},
+        driver="energy",
+        extras={settings.tcfe_config_kwarg: {"c0": b"123"}},
+    )
+    _bytes_to_b64(ai)
+
+    assert ai.extras[settings.tcfe_config_kwarg].get("c0") is None
+    assert ai.extras[settings.tcfe_config_kwarg].get(f"c0{B64_POSTFIX}") == "MTIz"
+
+
+def test_bytes_to_b64_opt_inp(water, settings):
+    opt = OptimizationInput(
+        initial_molecule=water,
+        input_specification={
+            "model": {"method": "b3lyp", "basis": "6-31g"},
+            "driver": "energy",
+            "extras": {settings.tcfe_config_kwarg: {"c0": b"123"}},
+        },
+    )
+    _bytes_to_b64(opt)
+
+    assert opt.input_specification.extras[settings.tcfe_config_kwarg].get("c0") is None
+    assert (
+        opt.input_specification.extras[settings.tcfe_config_kwarg].get(
+            f"c0{B64_POSTFIX}"
+        )
+        == "MTIz"
+    )
+
+
+def test_bytes_to_b64_list(water, settings):
+    ai = AtomicInput(
+        molecule=water,
+        model={"method": "b3lyp", "basis": "6-31g"},
+        driver="energy",
+        extras={settings.tcfe_config_kwarg: {"c0": b"123"}},
+    )
+    input_data = [ai, AtomicInput(**ai.dict())]
+    _bytes_to_b64(input_data)
+
+    for ai in input_data:
+        assert ai.extras[settings.tcfe_config_kwarg].get("c0") is None
+        assert ai.extras[settings.tcfe_config_kwarg].get(f"c0{B64_POSTFIX}") == "MTIz"
+
+
+def test_bytes_to_b64_opt_inp_list(water, settings):
+    opt = OptimizationInput(
+        initial_molecule=water,
+        input_specification={
+            "model": {"method": "b3lyp", "basis": "6-31g"},
+            "driver": "energy",
+            "extras": {settings.tcfe_config_kwarg: {"c0": b"123"}},
+        },
+    )
+    [opt, OptimizationInput(**opt.dict())]
+    _bytes_to_b64(opt)
+
+    assert opt.input_specification.extras[settings.tcfe_config_kwarg].get("c0") is None
+    assert (
+        opt.input_specification.extras[settings.tcfe_config_kwarg].get(
+            f"c0{B64_POSTFIX}"
+        )
+        == "MTIz"
+    )
+
+
+def test_b64_to_bytes_atomic_result(water, settings):
+    ar_dict = AtomicResult(
+        molecule=water,
+        model={"method": "b3lyp", "basis": "6-31g"},
+        driver="energy",
+        extras={settings.tcfe_config_kwarg: {"c0": b"123"}},
+        return_result=123.4,
+        provenance={"creator": "test suite"},
+        properties={},
+        success=True,
+        protocols={"native_files": "all"},
+        native_files={"c0_b64": "MTIz"},
+    ).dict()
+    _b64_to_bytes(ar_dict)
+
+    assert ar_dict["extras"][settings.tcfe_config_kwarg].get(f"c0{B64_POSTFIX}") is None
+    assert ar_dict["extras"][settings.tcfe_config_kwarg].get("c0") == b"123"
+
+
+def test_b64_to_bytes_opt_result(water, settings):
+    or_dict = OptimizationResult(
+        initial_molecule=water,
+        final_molecule=water,
+        success=True,
+        provenance={"creator": "test suite"},
+        energies=[123.4, 567.8],
+        input_specification={
+            "model": {"method": "b3lyp", "basis": "6-31g"},
+            "driver": "energy",
+            "extras": {settings.tcfe_config_kwarg: {"c0": b"123"}},
+        },
+        trajectory=[
+            AtomicResult(
+                molecule=water,
+                model={"method": "b3lyp", "basis": "6-31g"},
+                driver="energy",
+                extras={settings.tcfe_config_kwarg: {"c0": b"123"}},
+                return_result=123.4,
+                provenance={"creator": "test suite"},
+                properties={},
+                success=True,
+                protocols={"native_files": "all"},
+                native_files={"c0_b64": "MTIz"},
+            ),
+            AtomicResult(
+                molecule=water,
+                model={"method": "b3lyp", "basis": "6-31g"},
+                driver="energy",
+                extras={settings.tcfe_config_kwarg: {"c0": b"123"}},
+                return_result=123.4,
+                provenance={"creator": "test suite"},
+                properties={},
+                success=True,
+                protocols={"native_files": "all"},
+                native_files={"c0_b64": "MTIz"},
+            ),
+        ],
+    ).dict()
+    _b64_to_bytes(or_dict)
+
+    for ar in or_dict["trajectory"]:
+        assert ar["native_files"].get(f"c0{B64_POSTFIX}") is None
+        assert ar["native_files"].get("c0") == b"123"


### PR DESCRIPTION
… >= 0.24.0 to support native_files field

Add ability to pass wavefunction data via `AtomicInput.extras[tcfe:config]` and receive wavefunction (or any file) via `AtomicResult.native_files`