### PR TITLE
Increased read timeout from 5.0s -> 20.0s. Updated pre-commit mypy

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,8 +29,7 @@ repos:
     rev: v0.942
     hooks:
       - id: mypy
-        additional_dependencies: [tokenize-rt==3.2.0, pydantic>=1.0.0]
-        args: [tccloud, tests]
+        additional_dependencies: [tokenize-rt==3.2.0, pydantic>=1.0.0, types-toml>=0.10.7]
 
   - repo: local
     hooks:

--- a/tccloud/http_client.py
+++ b/tccloud/http_client.py
@@ -183,8 +183,12 @@ class _RequestsClient:
             data=data,
             params=params,
         )
-
-        with httpx.Client() as client:
+        # Leave default 5.0s timeout, incrase read timeout to 20.0 seconds to handle
+        # httpx.ReadTimeout exceptions seen by Ethan. I think the issue is the client
+        # is waiting while TCC retrieves results from backend and with large results
+        # this can take longer than 5 seconds. Will see if this solves issue...
+        # https://www.python-httpx.org/advanced/#fine-tuning-the-configuration
+        with httpx.Client(timeout=httpx.Timeout(5.0, read=20.0)) as client:
             response = client.send(request)
         response.raise_for_status()
         return response.json()


### PR DESCRIPTION
this is addressing the issue Ethan was occasionally having. I _think_ this is because the web server is getting large results from redis and it may take longer than 5 seconds to the client doesn't receive data for more than 5 seconds. Not 100% sure, but upped the limit from 5.0s -> 20.0s to see if this fixes the issue.

```python
The above exception was the direct cause of the following exception:                                                 
                                                                                                                     
Traceback (most recent call last):                                                                                   
  File "/home/curtie/7_FF_fitting/0_ff-optimizer/0_main_branch/ff-optimizer/ff_optimizer/qmengine.py", line 408, in c
omputeBatch                                                                                                          
    resultBatches = [futureResults[i].get() for i in range(stride)]                                                  
  File "/home/curtie/7_FF_fitting/0_ff-optimizer/0_main_branch/ff-optimizer/ff_optimizer/qmengine.py", line 408, in <
listcomp>                                                                                                            
    resultBatches = [futureResults[i].get() for i in range(stride)]                                                  
  File "/home/curtie/.local/lib/python3.8/site-packages/tccloud/models.py", line 88, in get                          
    self.status                                                                                                      
  File "/home/curtie/.local/lib/python3.8/site-packages/tccloud/models.py", line 114, in status                      
    self._state, self.result = self._result()                                                                        
  File "/home/curtie/.local/lib/python3.8/site-packages/tccloud/models.py", line 131, in _result                     
    return self.client.result(self.id.replace(GROUP_ID_PREFIX, ""))                                                  
  File "/home/curtie/.local/lib/python3.8/site-packages/tccloud/http_client.py", line 322, in result                 
    result = self._authenticated_request("get", f"/compute/result/{result_id}")                                      
  File "/home/curtie/.local/lib/python3.8/site-packages/tccloud/http_client.py", line 197, in _authenticated_request 
    return self._request(                                                                                            
  File "/home/curtie/.local/lib/python3.8/site-packages/tccloud/http_client.py", line 188, in _request               
    response = client.send(request)                                                                                  
  File "/home/curtie/.conda/envs/forcebalance/lib/python3.8/site-packages/httpx/_client.py", line 878, in send       
    response = self._send_handling_auth(                                                                             
  File "/home/curtie/.conda/envs/forcebalance/lib/python3.8/site-packages/httpx/_client.py", line 908, in _send_handl
ing_auth                                                                                                             
    response = self._send_handling_redirects(                                                                        
  File "/home/curtie/.conda/envs/forcebalance/lib/python3.8/site-packages/httpx/_client.py", line 947, in _send_handl
ing_redirects                                                                                                        
    response = self._send_single_request(request, timeout)                                                           
  File "/home/curtie/.conda/envs/forcebalance/lib/python3.8/site-packages/httpx/_client.py", line 983, in _send_singl
e_request                                                                                                            
    (status_code, headers, stream, extensions) = transport.handle_request(                                           
  File "/home/curtie/.conda/envs/forcebalance/lib/python3.8/site-packages/httpx/_transports/default.py", line 180, in
 handle_request                                                                                                      
    status_code, headers, byte_stream, extensions = self._pool.handle_request(                                       
  File "/home/curtie/.conda/envs/forcebalance/lib/python3.8/contextlib.py", line 131, in __exit__                    
    self.gen.throw(type, value, traceback)                                                                           
  File "/home/curtie/.conda/envs/forcebalance/lib/python3.8/site-packages/httpx/_transports/default.py", line 78, in 
map_httpcore_exceptions                                                                                              
    raise mapped_exc(message) from exc                                                                               
httpx.ReadTimeout: The read operation timed out   
```